### PR TITLE
fix!: Renamed `message_name` to `class_name`

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,11 +43,12 @@ And then execute:
 $ bundle
 ```
 
-## Not so quick start
+## Quick start
 
 1. Generate the protobuf ruby methods
    1. e.g `protoc --proto_path=. --ruby_out=. ./log.proto`
-2. Modify the `<format>` section to include `message_name`, which is your Protobuf message name, and `include_paths`, the path where the generated Ruby types are stored
+2. Modify the `<format>` section to include `class_name`, which is your Protobuf message name, and `include_paths`, the path where the generated Ruby types are stored
+   1. Given protobuf class `Your::Protobuf::Class::Name` class should be given as `Your.Protobuf.Class.Name` in `class_name`. The exact name can be found in the generated Ruby files
 
 
 ## Example

--- a/lib/fluent/plugin/formatter_protobuf.rb
+++ b/lib/fluent/plugin/formatter_protobuf.rb
@@ -33,7 +33,7 @@ module Fluent
       config_param :include_paths, :array, default: []
 
       # Protobuf message name
-      config_param :message_name, :string
+      config_param :class_name, :string
 
       def configure(conf)
         super(conf)
@@ -42,10 +42,10 @@ module Fluent
 
         @include_paths.each { |path| require_proto!(path) } unless @include_paths.empty?
 
-        message_lookup = Google::Protobuf::DescriptorPool.generated_pool.lookup(@message_name)
-        raise Fluent::ConfigError, "message name '#{@message_name}' not found" if message_lookup.nil?
+        class_lookup = Google::Protobuf::DescriptorPool.generated_pool.lookup(@class_name)
+        raise Fluent::ConfigError, "class name '#{@class_name}' not found" if class_lookup.nil?
 
-        @protobuf_class = message_lookup.msgclass
+        @protobuf_class = class_lookup.msgclass
       end
 
       def formatter_type

--- a/test/plugin/test_formatter_protobuf.rb
+++ b/test/plugin/test_formatter_protobuf.rb
@@ -16,38 +16,38 @@ class ProtobufFormatterTest < Test::Unit::TestCase
   sub_test_case 'configure' do
     test 'fail if include_paths is empty' do
       assert_raise(Fluent::ConfigError) do
-        create_driver({ message_name: '', include_paths: [] })
+        create_driver({ class_name: '', include_paths: [] })
       end
     end
 
     test 'fail if ruby files not found in the provided include paths' do
       assert_raise(Fluent::ConfigError) do
-        create_driver({ message_name: 'tutorial.AddressBook', include_paths: ['some/random/path'] })
+        create_driver({ class_name: 'tutorial.AddressBook', include_paths: ['some/random/path'] })
       end
     end
 
-    test 'fail if no protobuf class can be found with message_name' do
+    test 'fail if no protobuf class can be found with class_name' do
       assert_raise(Fluent::ConfigError) do
-        create_driver({ message_name: 'Some.Name', include_paths: VALID_INCLUDE_PATHS_ABSOLUTE })
+        create_driver({ class_name: 'Some.Name', include_paths: VALID_INCLUDE_PATHS_ABSOLUTE })
       end
     end
 
     test 'success if given valid relative paths in include paths' do
       assert_nothing_raised do
-        create_driver({ message_name: 'tutorial.AddressBook', include_paths: [VALID_INCLUDE_PATHS_RELATIVE] })
+        create_driver({ class_name: 'tutorial.AddressBook', include_paths: [VALID_INCLUDE_PATHS_RELATIVE] })
       end
     end
 
     test 'passes on valid configuration' do
       assert_nothing_raised do
-        create_driver({ message_name: 'tutorial.AddressBook', include_paths: VALID_INCLUDE_PATHS_ABSOLUTE })
+        create_driver({ class_name: 'tutorial.AddressBook', include_paths: VALID_INCLUDE_PATHS_ABSOLUTE })
       end
     end
   end
 
   sub_test_case 'format' do
     test 'encodes into Protobuf binary' do
-      formatter = create_formatter({ message_name: 'tutorial.AddressBook',
+      formatter = create_formatter({ class_name: 'tutorial.AddressBook',
                                      include_paths: VALID_INCLUDE_PATHS_ABSOLUTE })
 
       formatted = formatter.format('some-tag', 1234,


### PR DESCRIPTION
This is to align with
https://github.com/fluent-plugins-nursery/fluent-plugin-parser-protobuf