### PR TITLE
CI: fix ruby version in release-please workflow

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -21,7 +21,7 @@ jobs:
         uses: ruby/setup-ruby@afeafc3d1ab54a631816aba4c914a0081c12ff2f # v1.310.0
         with:
           bundler-cache: true
-          ruby-version: '2.5'
+          ruby-version: '4.0'
 
       - name: Publish to GPR
         run: |


### PR DESCRIPTION
fluent-plugin-formatter-protobuf supports Ruby 2.7 as minimum version.
https://github.com/fluent-plugins-nursery/fluent-plugin-formatter-protobuf/blob/2b926ec35e4d9a3cfd2d06d192950838423472af/fluent-plugin-formatter-protobuf.gemspec#L18

However, an older version is used in CI, and it is causing errors